### PR TITLE
Integration of Mayhem with thin-edge.io

### DIFF
--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -1,0 +1,61 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  PROJECTNAME: thin-edge.io
+  MAYHEMFILE: Mayhem/cc8y_translator.mayhemfile
+
+jobs:
+  build:
+    name: '${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.mayhem
+
+      - name: Start analysis for fuzz_redb
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -48,7 +48,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile.mayhem
 
-      - name: Start analysis for fuzz_redb
+      - name: Start analysis for fuzz_c8y_translator
         uses: ForAllSecure/mcode-action@v1
         with:
           mayhem-token: ${{ secrets.MAYHEM_TOKEN }}

--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -7,7 +7,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  PROJECTNAME: thin-edge.io
+  PROJECTNAME: thin-edge-io
   MAYHEMFILE: Mayhem/cc8y_translator.mayhemfile
 
 jobs:

--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -8,7 +8,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   PROJECTNAME: thin-edge-io
-  MAYHEMFILE: Mayhem/cc8y_translator.mayhemfile
+  MAYHEMFILE: Mayhem/c8y_translator.mayhemfile
 
 jobs:
   build:

--- a/Dockerfile.mayhem
+++ b/Dockerfile.mayhem
@@ -9,11 +9,11 @@ RUN cargo install cargo-fuzz
 
 # BUILD INSTRUCTIONS
 WORKDIR /thin-edge.io/crates/core/c8y_translator/fuzz
-RUN cargo +nightly fuzz build fuzz_target_1
+RUN cargo +nightly fuzz build fuzz_c8y_translator
 # Output binaries are placed in /thin-edge.io/crates/core/c8y_translator/fuzz/target/x86_64-unknown-linux-gnu/release/
 
 # Package Stage -- we package for a plain Ubuntu machine
 FROM --platform=linux/amd64 ubuntu:20.04
 
 # Copy the binary from the build stage to an Ubuntu docker image
-COPY --from=builder /thin-edge.io/crates/core/c8y_translator/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_1 /
+COPY --from=builder /thin-edge.io/crates/core/c8y_translator/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_c8y_translator /

--- a/Dockerfile.mayhem
+++ b/Dockerfile.mayhem
@@ -1,0 +1,19 @@
+# Use Rust to build
+FROM rustlang/rust:nightly as builder
+
+# Add source code to the build stage.
+ADD . /thin-edge.io
+WORKDIR /thin-edge.io
+
+RUN cargo install cargo-fuzz
+
+# BUILD INSTRUCTIONS
+WORKDIR /thin-edge.io/crates/core/c8y_translator/fuzz
+RUN cargo +nightly fuzz build fuzz_target_1
+# Output binaries are placed in /thin-edge.io/crates/core/c8y_translator/fuzz/target/x86_64-unknown-linux-gnu/release/
+
+# Package Stage -- we package for a plain Ubuntu machine
+FROM --platform=linux/amd64 ubuntu:20.04
+
+# Copy the binary from the build stage to an Ubuntu docker image
+COPY --from=builder /thin-edge.io/crates/core/c8y_translator/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_1 /

--- a/Mayhem/c8y_translator.mayhemfile
+++ b/Mayhem/c8y_translator.mayhemfile
@@ -2,4 +2,4 @@ project: thin-edge-io
 target: c8y_translator
 
 cmds:
-  - cmd: /fuzz_target_1
+  - cmd: /fuzz_c8y_translator

--- a/Mayhem/c8y_translator.mayhemfile
+++ b/Mayhem/c8y_translator.mayhemfile
@@ -1,0 +1,5 @@
+project: thin-edge.io
+target: c8y_translator
+
+cmds:
+  - cmd: /fuzz_target_1

--- a/Mayhem/c8y_translator.mayhemfile
+++ b/Mayhem/c8y_translator.mayhemfile
@@ -1,4 +1,4 @@
-project: thin-edge.io
+project: thin-edge-io
 target: c8y_translator
 
 cmds:

--- a/crates/core/c8y_translator/fuzz/Cargo.lock
+++ b/crates/core/c8y_translator/fuzz/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "c8y_translator"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "clock",
  "json-writer",
@@ -56,7 +56,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clock"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "mockall",
  "time",
@@ -97,7 +97,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "json-writer"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -309,7 +309,7 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "thin_edge_json"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "clock",
  "json-writer",

--- a/crates/core/c8y_translator/fuzz/Cargo.toml
+++ b/crates/core/c8y_translator/fuzz/Cargo.toml
@@ -21,7 +21,7 @@ path = ".."
 members = ["."]
 
 [[bin]]
-name = "fuzz_target_1"
+name = "fuzz_c8y_translator"
 path = "fuzz_targets/fuzz_target_1.rs"
 test = false
 doc = false

--- a/crates/core/c8y_translator/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/crates/core/c8y_translator/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -4,5 +4,7 @@ use libfuzzer_sys::fuzz_target;
 use c8y_translator::json;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = json::from_thin_edge_json(std::str::from_utf8(data).unwrap());
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = json::from_thin_edge_json(s);
+    }
 });


### PR DESCRIPTION
## Proposed changes

Added integration of Mayhem to the `thin-edge.io` project. This adds a GitHub action which creates a Docker image and automatically uses Mayhem to fuzz the project. Integration for this repository was relatively straightforward, as LibFuzzer was already used in the project. A `Dockerfile` was added to create the image, and a Mayhemfile and YAML file were added to run the Mayhem GitHub action.

